### PR TITLE
Updates Constraint Kit repo to HTTPS over SSH

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "ConstraintKit",
-                 url: "git@github.com:gymshark/ios-constraint-kit.git",
+                 url: "https://github.com/gymshark/ios-constraint-kit.git",
                  .upToNextMinor(from: "0.0.2"))
     ],
     targets: [


### PR DESCRIPTION
# Pull Request Template

## Description

Use HTTPS for dependency over SSH to prevent SSH errors on cloning.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

